### PR TITLE
Create local_compile.md

### DIFF
--- a/docs/local_compile.md
+++ b/docs/local_compile.md
@@ -1,0 +1,14 @@
+```
+## conda install -y go
+## conda install -y gcc --force-reinstall
+git clone https://github.com/dennwc/cas.git
+cd cas
+go get -u
+go build ./*.go
+cd cmd/cas
+go get -u
+go build ./*.go
+ln blobs cas
+## Move cas to a executable directory. 
+## ln cas ~/bin/
+```


### PR DESCRIPTION
Not familiar with the typical Go compile process, but the procedure added in `local_compile.md` worked for me whereas the current instructions did not work. Haven't checked if the actual binary fails to work or not yet! But at least it shows the `cas` dialog:

```
Content Addressable Storage

Usage:
  cas [command]

Available Commands:
  blob        commands related to the binary data in content-addressable storage
  checkout    restore a pin or hash to a specified path
  completion  Generate the autocompletion script for the specified shell
  fetch       store the URL or file in the content-addressable storage
  hash        hash files
  help        Help about any command
  http        commands related to HTTP protocol
  init        init content-addressable storage in current directory
  pin         set a named pin pointing to a ref
  pipeline    process blobs via a pipeline
  proxy       proxy http requests and save them to CAS
  pull        store the URL or file in the content-addressable storage under a named pin
  schema      commands related to the CAS schema
  serve       serve CAS over HTTP
  sync        syncs one or more remote blobs

Flags:
  -h, --help   help for cas

Use "cas [command] --help" for more information about a command.
```